### PR TITLE
Make iOS nuget package work on macOS

### DIFF
--- a/Nuget/build/Anyline.Xamarin.SDK.iOS.targets
+++ b/Nuget/build/Anyline.Xamarin.SDK.iOS.targets
@@ -6,13 +6,9 @@
 
   <Target Name="_Anyline_AddLinkMetadataToNuGetBundleResources" BeforeTargets="_CompileInterfaceDefinitions" DependsOnTargets="ResolveReferences">
 
-    <PropertyGroup>
-      <_ContentFilePathPattern>^.*\\contentFiles\\\w*\\[\w.]*\\</_ContentFilePathPattern>
-    </PropertyGroup>
-
     <ItemGroup>
-      <BundleResource Update="@(BundleResource)" Condition="'%(BundleResource.NuGetItemType)' != '' And '%(BundleResource.Link)' == ''">
-        <Link>$([System.Text.RegularExpressions.Regex]::Replace(%(BundleResource.FullPath), $(_ContentFilePathPattern), '', System.Text.RegularExpressions.RegexOptions.IgnoreCase))</Link>
+      <BundleResource Update="@(BundleResource)" Condition=" '%(BundleResource.NuGetPackageId)' == 'Anyline.Xamarin.SDK.iOS' And '%(BundleResource.NuGetItemType)' != '' And '%(BundleResource.Link)' == ''">
+        <Link>$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory)/../contentFiles/any/xamarin.ios10/, %(BundleResource.FullPath)))</Link>
       </BundleResource>
     </ItemGroup>
 

--- a/Nuget/build/Anyline.Xamarin.SDK.iOS.targets
+++ b/Nuget/build/Anyline.Xamarin.SDK.iOS.targets
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <BundleResource Update="@(BundleResource)" Condition=" '%(BundleResource.NuGetPackageId)' == 'Anyline.Xamarin.SDK.iOS' And '%(BundleResource.NuGetItemType)' != '' And '%(BundleResource.Link)' == ''">
-        <Link>$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory)/../contentFiles/any/xamarin.ios10/, %(BundleResource.FullPath)))</Link>
+        <Link>$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory)\..\contentFiles\any\xamarin.ios10\, %(BundleResource.FullPath)))</Link>
       </BundleResource>
     </ItemGroup>
 


### PR DESCRIPTION
Currently the iOS NuGet package only works when developing a Xamarin app on Windows connected to a mac via ssh.

This change updates the bundle items link paths in a cross platform way.

 ⚠ I have not tested this on Windows, it would be great if you can try it out.