### PR TITLE
Make CoreNFC optional for older iOS devices

### DIFF
--- a/BindingSource/AnylineXamarinSDK.iOS/Anyline.linkwith.cs
+++ b/BindingSource/AnylineXamarinSDK.iOS/Anyline.linkwith.cs
@@ -3,7 +3,8 @@ using ObjCRuntime;
 
 [assembly: LinkWith ("Anyline.a",    
     LinkTarget = LinkTarget.Simulator | LinkTarget.ArmV7 | LinkTarget.ArmV7s | LinkTarget.Arm64,
-    Frameworks = "ImageIO AssetsLibrary AVFoundation CoreMedia CoreVideo AudioToolbox QuartzCore Accelerate Security CoreMotion CoreImage WebKit CoreNFC",
+    Frameworks = "ImageIO AssetsLibrary AVFoundation CoreMedia CoreVideo AudioToolbox QuartzCore Accelerate Security CoreMotion CoreImage WebKit",
+    WeakFrameworks = "CoreNFC",
     LinkerFlags = "-lz -lc++ -liconv -all_load -ObjC -v"
 
     // redefine all extern const symbols, see https://forums.xamarin.com/discussion/8572/how-do-you-bind-extern-nsstring-const


### PR DESCRIPTION
Fixes #16

This change is equivalent of marking CoreNFC as `Optional` in the Xcode UI ([see here](https://stackoverflow.com/questions/44946057/dyld-library-not-loaded-rpath-corenfc-framework-corenfc-ios11-and-xcode-9-be/52868674#52868674))

This is **untested**!